### PR TITLE
Account for padding on modal width for small devices.

### DIFF
--- a/src/components/SkillRoller.css
+++ b/src/components/SkillRoller.css
@@ -179,7 +179,7 @@
 
 @media (max-width: 768px) {
   .stunts-modal {
-    width: 100%;
+    width: calc(100% - 3rem); /* left and right padding: 1.5rem each */
     border-radius: 16px 16px 0 0;
   }
 }


### PR DESCRIPTION
Overlooked the padding for on the modal when setting the width. Added a calc() to account for that.

This is for issue #8 

Below is a screenshot of the fixed version.

<img width="654" alt="Screenshot 2025-06-02 at 8 52 13 PM" src="https://github.com/user-attachments/assets/815edf80-9858-4150-bbe4-8eef7be206ec" />
