### PR TITLE
Issue 11: Update SkillRoller and RotRoller fields to allow backspacing placeholders

### DIFF
--- a/src/components/RotRoller.tsx
+++ b/src/components/RotRoller.tsx
@@ -30,6 +30,7 @@ type ProtectionRoll = {
  */
 const RotRoller = () => {
   const [rotPoints, setRotPoints] = useState<number>(1)
+  const [rotPointsInput, setRotPointsInput] = useState<string>('1')
   const [protection, setProtection] = useState<ProtectionType>({
     hasRotResistant: false,
     hasRotSuit: false,
@@ -166,15 +167,13 @@ const RotRoller = () => {
             type="number"
             id="rotPoints"
             min="1"
-            value={rotPoints}
+            value={rotPointsInput}
             onChange={(e) => {
               const value = e.target.value;
-              // Allow empty input
+              setRotPointsInput(value);
               if (value === '') {
-                setRotPoints(1);
                 return;
               }
-              // Parse the number and ensure it's at least 1
               const numValue = parseInt(value);
               if (!isNaN(numValue)) {
                 setRotPoints(Math.max(1, numValue));
@@ -182,6 +181,7 @@ const RotRoller = () => {
             }}
             onBlur={(e) => {
               if (e.target.value === '') {
+                setRotPointsInput('1');
                 setRotPoints(1);
                 handleResetRolls();
               }

--- a/src/components/RotRoller.tsx
+++ b/src/components/RotRoller.tsx
@@ -172,13 +172,17 @@ const RotRoller = () => {
               // Allow empty input
               if (value === '') {
                 setRotPoints(1);
-                handleResetRolls();
                 return;
               }
               // Parse the number and ensure it's at least 1
               const numValue = parseInt(value);
               if (!isNaN(numValue)) {
                 setRotPoints(Math.max(1, numValue));
+              }
+            }}
+            onBlur={(e) => {
+              if (e.target.value === '') {
+                setRotPoints(1);
                 handleResetRolls();
               }
             }}
@@ -223,10 +227,31 @@ const RotRoller = () => {
                 min="1"
                 max="6"
                 value={protection.rotSuitRating}
-                onChange={(e) => setProtection(prev => ({
-                  ...prev,
-                  rotSuitRating: Math.max(1, Math.min(6, parseInt(e.target.value) || 3))
-                }))}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  if (value === '') {
+                    setProtection(prev => ({
+                      ...prev,
+                      rotSuitRating: 3
+                    }));
+                  } else {
+                    const numValue = parseInt(value);
+                    if (!isNaN(numValue)) {
+                      setProtection(prev => ({
+                        ...prev,
+                        rotSuitRating: Math.max(1, Math.min(6, numValue))
+                      }));
+                    }
+                  }
+                }}
+                onBlur={(e) => {
+                  if (e.target.value === '') {
+                    setProtection(prev => ({
+                      ...prev,
+                      rotSuitRating: 3
+                    }));
+                  }
+                }}
               />
             </div>
           )}

--- a/src/components/SkillRoller.tsx
+++ b/src/components/SkillRoller.tsx
@@ -15,8 +15,11 @@ const SkillRoller: React.FC = () => {
   const [skillCategory, setSkillCategory] = useState<SkillCategory>('basic');
   const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
   const [attributeDice, setAttributeDice] = useState(0);
+  const [attributeDiceInput, setAttributeDiceInput] = useState('0');
   const [skillDice, setSkillDice] = useState(0);
+  const [skillDiceInput, setSkillDiceInput] = useState('0');
   const [gearDice, setGearDice] = useState(0);
+  const [gearDiceInput, setGearDiceInput] = useState('0');
   const [currentSuccesses, setCurrentSuccesses] = useState(0);
   const [expandedStuntId, setExpandedStuntId] = useState<string | null>(null);
   const [showStuntsModal, setShowStuntsModal] = useState(false);
@@ -106,20 +109,21 @@ const SkillRoller: React.FC = () => {
                 type="number"
                 className="dice-input-field-attribute"
                 min="0"
-                value={attributeDice}
+                value={attributeDiceInput}
                 onChange={(e) => {
                   const value = e.target.value;
+                  setAttributeDiceInput(value);
                   if (value === '') {
-                    setAttributeDice(0);
-                  } else {
-                    const numValue = parseInt(value);
-                    if (!isNaN(numValue)) {
-                      setAttributeDice(Math.max(0, numValue));
-                    }
+                    return;
+                  }
+                  const numValue = parseInt(value);
+                  if (!isNaN(numValue)) {
+                    setAttributeDice(Math.max(0, numValue));
                   }
                 }}
                 onBlur={(e) => {
                   if (e.target.value === '') {
+                    setAttributeDiceInput('0');
                     setAttributeDice(0);
                   }
                 }}
@@ -131,20 +135,21 @@ const SkillRoller: React.FC = () => {
                 type="number"
                 className="dice-input-field-skill"
                 min="0"
-                value={skillDice}
+                value={skillDiceInput}
                 onChange={(e) => {
                   const value = e.target.value;
+                  setSkillDiceInput(value);
                   if (value === '') {
-                    setSkillDice(0);
-                  } else {
-                    const numValue = parseInt(value);
-                    if (!isNaN(numValue)) {
-                      setSkillDice(Math.max(0, numValue));
-                    }
+                    return;
+                  }
+                  const numValue = parseInt(value);
+                  if (!isNaN(numValue)) {
+                    setSkillDice(Math.max(0, numValue));
                   }
                 }}
                 onBlur={(e) => {
                   if (e.target.value === '') {
+                    setSkillDiceInput('0');
                     setSkillDice(0);
                   }
                 }}
@@ -156,20 +161,21 @@ const SkillRoller: React.FC = () => {
                 type="number"
                 className="dice-input-field-gear"
                 min="0"
-                value={gearDice}
+                value={gearDiceInput}
                 onChange={(e) => {
                   const value = e.target.value;
+                  setGearDiceInput(value);
                   if (value === '') {
-                    setGearDice(0);
-                  } else {
-                    const numValue = parseInt(value);
-                    if (!isNaN(numValue)) {
-                      setGearDice(Math.max(0, numValue));
-                    }
+                    return;
+                  }
+                  const numValue = parseInt(value);
+                  if (!isNaN(numValue)) {
+                    setGearDice(Math.max(0, numValue));
                   }
                 }}
                 onBlur={(e) => {
                   if (e.target.value === '') {
+                    setGearDiceInput('0');
                     setGearDice(0);
                   }
                 }}

--- a/src/components/SkillRoller.tsx
+++ b/src/components/SkillRoller.tsx
@@ -107,7 +107,22 @@ const SkillRoller: React.FC = () => {
                 className="dice-input-field-attribute"
                 min="0"
                 value={attributeDice}
-                onChange={(e) => setAttributeDice(Math.max(0, parseInt(e.target.value) || 0))}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  if (value === '') {
+                    setAttributeDice(0);
+                  } else {
+                    const numValue = parseInt(value);
+                    if (!isNaN(numValue)) {
+                      setAttributeDice(Math.max(0, numValue));
+                    }
+                  }
+                }}
+                onBlur={(e) => {
+                  if (e.target.value === '') {
+                    setAttributeDice(0);
+                  }
+                }}
               />
             </div>
             <div className="dice-input">
@@ -117,7 +132,22 @@ const SkillRoller: React.FC = () => {
                 className="dice-input-field-skill"
                 min="0"
                 value={skillDice}
-                onChange={(e) => setSkillDice(Math.max(0, parseInt(e.target.value) || 0))}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  if (value === '') {
+                    setSkillDice(0);
+                  } else {
+                    const numValue = parseInt(value);
+                    if (!isNaN(numValue)) {
+                      setSkillDice(Math.max(0, numValue));
+                    }
+                  }
+                }}
+                onBlur={(e) => {
+                  if (e.target.value === '') {
+                    setSkillDice(0);
+                  }
+                }}
               />
             </div>
             <div className="dice-input">
@@ -127,7 +157,22 @@ const SkillRoller: React.FC = () => {
                 className="dice-input-field-gear"
                 min="0"
                 value={gearDice}
-                onChange={(e) => setGearDice(Math.max(0, parseInt(e.target.value) || 0))}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  if (value === '') {
+                    setGearDice(0);
+                  } else {
+                    const numValue = parseInt(value);
+                    if (!isNaN(numValue)) {
+                      setGearDice(Math.max(0, numValue));
+                    }
+                  }
+                }}
+                onBlur={(e) => {
+                  if (e.target.value === '') {
+                    setGearDice(0);
+                  }
+                }}
               />
             </div>
           </div>


### PR DESCRIPTION
The number field wasn't allowing the user to backspace the original values in the fields because the state we were maintaining on them was allowed to be cleared. These changes:

- Allow users to clear number input fields by backspacing
- Maintain minimum values (0 for dice, 1 for rot points) only on blur
- Separate input display state from actual number values
- Fixes issue where backspace key couldn't clear default values
- Particularly improves mobile experience where cursor placement is difficult

This solves for Issue #11 . 